### PR TITLE
Add Debian Image Versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # featurization-deployment
 This is the main repo for featurization deployment for heavy model series like ConvNext
+
+### Python Image
+- To run heavy modules like tensorflow, you need to have the Debian versions like **bookwork** and **bullseye**.

--- a/flask/Dockerfile
+++ b/flask/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12.3-alpine
+FROM python:3.12.3-bookworm
 
 WORKDIR /flask
 

--- a/flask/app.py
+++ b/flask/app.py
@@ -1,10 +1,11 @@
 from flask import Flask, request, jsonify
+import tensorflow as tf
 
 app = Flask(__name__)
 
 @app.route("/")
 def home():
-    return "Hello, Flask!"
+    return "Hello, Flask!: {}".format(tf.__version__)
 
 @app.route('/save_data')
 def save_data():

--- a/flask/requirements.txt
+++ b/flask/requirements.txt
@@ -1,1 +1,2 @@
 Flask==3.0.3
+tensorflow


### PR DESCRIPTION
What is this for:
modules like tensorflow only works with python debian images versions.